### PR TITLE
Fix width problem

### DIFF
--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -30,13 +30,11 @@
             });
 
             mdEditor.css({
-                width: defaults.width,
                 height: defaults.height,
                 fontSize: defaults.fontSize
             });
 
             mdPreview.css({
-                width: defaults.width,
                 height: defaults.height
             });
 


### PR DESCRIPTION
``` js
$('div#editor').markdownEditor({
  preview: true,
  width: '80%'
});
```

In previous version's html:

``` html
<div id="editor" class="md-container" style="width: 80%">
  <div id="md-editor ace-editor ace-tomorrow" style="widht: 80%; height: 400px;
  font-size:14px; display: block;" draggable="false">
  </div>
</div>
```

In this version's html:

``` html
<div id="editor" class="md-container" style="width: 80%">
  <div id="md-editor ace-editor ace-tomorrow" style="height: 400px;
  font-size:14px; display: block;" draggable="false">
  </div>
</div>
```
