### PR TITLE
Don't request without any images

### DIFF
--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -65,9 +65,7 @@
                 plugin.find('.md-input-upload').on('change', function() {
                     var files = $(this).get(0).files;
 
-                    if (files.length) {
-                        uploadFiles(defaults.uploadPath, $(this).get(0).files, editor, snippetManager, mdLoading);
-                    }
+                    uploadFiles(defaults.uploadPath, $(this).get(0).files, editor, snippetManager, mdLoading);
                 });
 
                 plugin.on('dragenter', function (e) {
@@ -223,6 +221,9 @@
     };
 
     function uploadFiles (url, files, editor, snippetManager, loading) {
+        if (!files.length) {
+          return;
+        }
 
         loading.show();
 


### PR DESCRIPTION
Currently, the request with empty body might be sent on drag & drop.
It is unnecessary for web server.
