### PR TITLE
Loose dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.1",
-    "ace-builds": "~1.1.8"
+    "bootstrap": "< 4",
+    "ace-builds": "< 2"
   }
 }


### PR DESCRIPTION
[Ace editor has new releases (1.2.x)](https://github.com/ajaxorg/ace/releases)
but `~1.1.8` means `>= 1.1.8 < 1.2.0`.
And it also bootstrap should be.