### PR TITLE
Adds ability to create custom toolbar items [WIP]

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                     onPreview: function (content, callback) {
                         callback( marked(content) );
                     },
-                    buttons: {
+                    toolbar: {
                         html: html,
                         onCreated: function(container) {
                             console.log('Elements added to DOM, put your manipulation in here (if needed)');

--- a/index.html
+++ b/index.html
@@ -54,11 +54,36 @@
         <script>
 
             jQuery(document).ready(function($) {
+                /*
+                 * Custom HTML for custom toolbar items
+                 */
+                html = '<div class="btn-group">';
+                html += '<select class="form-control input-sm md-select" data-btn="customCallback">' +
+                    '<option value="value1">Value One</option>' +
+                    '<option value="value2">Value Two</option>' +
+                    '</select>';
+                html += '</div>';
+
+                html += '<div class="btn-group">';
+                    html += '<button type="button" data-mdtooltip="tooltip" title="Add hello world" class="md-btn btn btn-sm btn-default" data-btn="helloWorld">HW</button>';
+                html += '</div>';
 
                 $('#editor').markdownEditor({
                     preview: true,
                     onPreview: function (content, callback) {
                         callback( marked(content) );
+                    },
+                    buttons: {
+                        html: html,
+                        callbacks: {
+                            customCallback: function($element, editor, container, selectedText) {
+                                console.log('customCallback called');
+                                editor.insert($element.val());
+                            },
+                            helloWorld: function($element, editor, container, selectedText) {
+                                editor.insert('Hello World');
+                            }
+                        }
                     }
                 });
 

--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
                     },
                     buttons: {
                         html: html,
+                        onCreated: function(container) {
+                            console.log('Elements added to DOM, put your manipulation in here (if needed)');
+                        },
                         callbacks: {
                             customCallback: function($element, editor, container, selectedText) {
                                 console.log('customCallback called');

--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -425,7 +425,7 @@
         uploadPath: '',
         toolbar: {
             html: '',
-            onCreated: function(container) { },
+            onCreated: function() { },
             callbacks: {}
         },
         preview: false,

--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -142,6 +142,8 @@
                     }
                 html += '</div>'; // .btn-group
 
+                html += options.buttons.html;
+
                 if (options.fullscreen === true) {
                     html += '<div class="btn-group pull-right">';
                         html += '<button type="button" class="md-btn btn btn-sm btn-default" data-btn="fullscreen"><span class="glyphicon glyphicon-fullscreen"></span> ' + options.label.btnFullscreen + '</button>';
@@ -362,6 +364,23 @@
                     }
 
                     editor.resize();
+                } else if (btnType in options.buttons.callbacks) {
+                    var element = $(this);
+                    var callback = options.buttons.callbacks[btnType];
+                    callback(element, editor, container, selectedText);
+                }
+
+                editor.focus();
+            });
+
+            container.find('.md-select').change(function() {
+                var btnType = $(this).data('btn'),
+                    selectedText = editor.session.getTextRange(editor.getSelectionRange()),
+                    element = $(this);
+
+                if (btnType in options.buttons.callbacks) {
+                    var callback = options.buttons.callbacks[btnType];
+                    callback(element, editor, container, selectedText);
                 }
 
                 editor.focus();
@@ -401,6 +420,10 @@
         fullscreen: true,
         imageUpload: false,
         uploadPath: '',
+        buttons: {
+            html: '',
+            callbacks: {}
+        },
         preview: false,
         onPreview: function (content, callback) {
             callback(content);

--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -142,7 +142,7 @@
                     }
                 html += '</div>'; // .btn-group
 
-                html += options.buttons.html;
+                html += options.toolbar.html;
 
                 if (options.fullscreen === true) {
                     html += '<div class="btn-group pull-right">';
@@ -364,9 +364,9 @@
                     }
 
                     editor.resize();
-                } else if (btnType in options.buttons.callbacks) {
+                } else if (btnType in options.toolbar.callbacks) {
                     var element = $(this);
-                    var callback = options.buttons.callbacks[btnType];
+                    var callback = options.toolbar.callbacks[btnType];
                     callback(element, editor, container, selectedText);
                 }
 
@@ -378,8 +378,8 @@
                     selectedText = editor.session.getTextRange(editor.getSelectionRange()),
                     element = $(this);
 
-                if (btnType in options.buttons.callbacks) {
-                    var callback = options.buttons.callbacks[btnType];
+                if (btnType in options.toolbar.callbacks) {
+                    var callback = options.toolbar.callbacks[btnType];
                     callback(element, editor, container, selectedText);
                 }
 
@@ -387,7 +387,7 @@
             });
 
             // Trigger event to manipulate custom toolbar items
-            buttons.onCreated(container);
+            options.toolbar.onCreated(container);
 
             return this;
         },
@@ -423,7 +423,7 @@
         fullscreen: true,
         imageUpload: false,
         uploadPath: '',
-        buttons: {
+        toolbar: {
             html: '',
             onCreated: function(container) { },
             callbacks: {}

--- a/src/bootstrap-markdown-editor.js
+++ b/src/bootstrap-markdown-editor.js
@@ -386,6 +386,9 @@
                 editor.focus();
             });
 
+            // Trigger event to manipulate custom toolbar items
+            buttons.onCreated(container);
+
             return this;
         },
         content: function () {
@@ -422,6 +425,7 @@
         uploadPath: '',
         buttons: {
             html: '',
+            onCreated: function(container) { },
             callbacks: {}
         },
         preview: false,


### PR DESCRIPTION
This PR adds the (basic) ability to add custom toolbar items.

This feature adds one option to the `options` variable: `toolbar`. It has the following properties:

* `html` contains the HTML markup which is added between the default buttons and the preview buttons (on the right).
* `onCreated` is a callback which is called after the editor adds the element to the DOM. It has the parameter `container` which holds the jQuery container of the editor.
* `callbacks` is a hash list with property names being the name of the callback and their value being a callback (parameters: `element, editor, container, selectedText`). If the `btn-data` property is provided, its value must correspond to a callback with the same name within the `callbacks` list.

Take a look at the `index.html` file which holds an example.

Note: I chose not to provide any API to add buttons, comboboxes, checkboxes etc. to make this extension a little more "light". Also it gives the developer to add any kind of control to the editor :-)

Note: I did not update the javascript within the `dist` folder yet.

What do you think?

(This PR closes #5)